### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
             </dependency>
           </dependencies>
           <configuration>
-            <forkCount>1</forkCount>
+            <forkCount>1.5C</forkCount>
             <reuseForks>true</reuseForks>
             <argLine></argLine>
           </configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -164,7 +164,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<forkCount>1</forkCount>
+					<forkCount>1.5C</forkCount>
 					<reuseForks>true</reuseForks>
                                         <!-- Manage memory to set a more agressive GC, Openllet create a large number of small objets, so it is good. -->
 					<argLine>-XX:+UseG1GC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=25 -XX:GCTimeRatio=18 -XX:+UseStringDeduplication</argLine>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
