### PR TITLE
openllet-core: avoid version range for internal dependency

### DIFF
--- a/module-core/pom.xml
+++ b/module-core/pom.xml
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>openllet-functions</artifactId>
-			<version>[${project.version}]</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jgrapht</groupId>


### PR DESCRIPTION
The internal / cross-module dependency from openllet-core to openllet-functions is denoted as an enforced version (`<version>[x]</version>`) instead of a more relaxed / recommended version (`<version>x</version>`), see also https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html. All other internal dependencies use the default, e.g. from openllet-owlapi to openllet-core.

I suggest to remove the enforced version and use a recommended version instead, for consistency with the other Openllet modules.

Background:
I noticed this when I was locally installing the current SNAPSHOT and wanted to use it with [sbt](https://github.com/sbt/sbt), which uses [Coursier](https://github.com/coursier/coursier). Coursier could not resolve the openllet-functions SNAPSHOT locally; but I suspect that is a bug in Coursier and not actually a problem in the Openllet pom. As Coursier is having a lot more important issues, I think it is currently not worth my effort to investigate this more.