### PR TITLE
OWLWGTestCase: increase timeout from 10s to 60s

### DIFF
--- a/module-owlapi/src/test/java/openllet/pellet/owlapi/test/OWLWGTestCase.java
+++ b/module-owlapi/src/test/java/openllet/pellet/owlapi/test/OWLWGTestCase.java
@@ -53,11 +53,13 @@ public class OWLWGTestCase
 
 	public static Object _lock = new Object();
 
+	public static long TIMEOUT_SEC = 60;
+
 	/**
 	 * Ensure that test cases timeout after 10 seconds. This is in slightly broader than the one second timeout for each PelletOA3TestRunner.
 	 */
 	@Rule
-	public Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
+	public Timeout timeout = new Timeout(TIMEOUT_SEC, TimeUnit.SECONDS);
 
 	/**
 	 * The dockerVM that run Travis is this time slow my i5-3570K
@@ -148,7 +150,7 @@ public class OWLWGTestCase
 			{
 				KnowledgeBaseImpl._logger.setLevel(Level.WARNING);
 
-				final Collection<TestRunResult> results = new PelletTestRunner().run(_test, 1 * 1000 * _travisLowSpeed); // One second of timeout : really enough if every thing work well.
+				final Collection<TestRunResult> results = new PelletTestRunner().run(_test, TIMEOUT_SEC * 1000 * _travisLowSpeed);
 				for (final TestRunResult result : results)
 				{
 					final RunResultType resultType = result.getResultType();


### PR DESCRIPTION
Partially cherry-picked from 44202b034c at https://github.com/cristianolongoodhl/openllet-jena4.10/tree/jena4.8.0

I often encounter timeouts in the test case `WebOnt-description-logic-905`.

This has been authored by @cristianolongoodhl in #99, but is unrelated to the primary changes of that PR, so I think it is worth being applied separately.