### PR TITLE
Bump vulnerable transitive deps (jackson, commons-*)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,17 +167,17 @@
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-core</artifactId>
-         <version>2.12.5</version>
+         <version>2.18.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.12.5</version>
+        <version>2.18.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.12.5</version>
+        <version>2.18.8</version>
       </dependency>
       <dependency>
          <groupId>com.github.jsonld-java</groupId>
@@ -197,12 +197,30 @@
       <dependency>
         <groupId>commons-io</groupId> 
          <artifactId>commons-io</artifactId>
-         <version>2.11.0</version>
+         <version>2.18.0</version>
       </dependency>
       <dependency>
          <groupId>javax.xml.bind</groupId>
          <artifactId>jaxb-api</artifactId>
          <version>2.3.1</version>
+      </dependency>
+      <!-- Security: pin patched versions of transitive Apache Commons libs
+           (CVE-2022-42889 commons-text RCE, CVE-2024-25710/-26308 commons-compress,
+           CVE-2025-48924 commons-lang3). -->
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-text</artifactId>
+         <version>1.13.0</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-compress</artifactId>
+         <version>1.27.1</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-lang3</artifactId>
+         <version>3.18.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fixes CVE-2022-42889 (commons-text RCE), CVE-2024-25710/-26308 (commons-compress), CVE-2025-48924 (commons-lang3), CVE-2024-47554 (commons-io), and 4 jackson-databind/core advisories, via the parent POM dependencyManagement.